### PR TITLE
Feat/client env service

### DIFF
--- a/payroll-processor-client/src/app/shared/env.service.ts
+++ b/payroll-processor-client/src/app/shared/env.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { Environment } from '../../environments/environment-types';
+import { environment } from '../../environments/environment';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EnvService {
+  get env(): Environment {
+    return environment;
+  }
+
+  get apiRootUrl(): string {
+    return `${this.env}/api`;
+  }
+}

--- a/payroll-processor-client/src/environments/environment-types.ts
+++ b/payroll-processor-client/src/environments/environment-types.ts
@@ -1,0 +1,4 @@
+export interface Environment {
+  production: boolean;
+  domain: string;
+}

--- a/payroll-processor-client/src/environments/environment.dev.ts
+++ b/payroll-processor-client/src/environments/environment.dev.ts
@@ -2,7 +2,5 @@ import { Environment } from './environment-types';
 
 export const environment: Environment = {
   production: false,
-  // This should come from the launch.json for the API
-  domain: '<TODO>'
-};
-
+  domain: 'https://nitro-km-payroll-processor.azurewebsites.net'
+}

--- a/payroll-processor-client/src/environments/environment.prod.ts
+++ b/payroll-processor-client/src/environments/environment.prod.ts
@@ -1,3 +1,6 @@
-export const environment = {
-  production: true
+import { Environment } from './environment-types';
+
+export const environment: Environment = {
+  production: true,
+  domain: 'https://nitro-km-payroll-processor.azurewebsites.net'
 };

--- a/payroll-processor-client/tsconfig.json
+++ b/payroll-processor-client/tsconfig.json
@@ -7,6 +7,11 @@
     "declaration": false,
     "downlevelIteration": true,
     "experimentalDecorators": true,
+    // TODO - we'll want to enable these incrementally, currently they'll cause compilation errors
+    // "strict": true,
+    // "noImplicitReturns": true,
+    // "noImplicitThis": true,
+    // "noImplicitAny": true,
     "module": "esnext",
     "moduleResolution": "node",
     "importHelpers": true,
@@ -20,7 +25,7 @@
     ]
   },
   "angularCompilerOptions": {
-    "fullTemplateTypeCheck": true,
+    "strictTemplates": true,
     "strictInjectionParameters": true
   }
 }


### PR DESCRIPTION
Adds a new `EnvService` abstraction to prevent the app from consuming `environment.ts` directly and improve testability.

Also adds an `Environment` abstraction to force all environment files to match the same schema and give a consistent shape to environment consumption in the app.

Also adds some tsconfig updates that we can slowly uncomment to improve the type checking.