### PR TITLE
Docs: add mermaid diagrams

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,44 @@
+# Architecture
+
+## Diagrams
+
+Get all employees
+
+```mermaid
+sequenceDiagram
+    autonumber
+    Client->>Employees_Get: XHR Request
+    Employees_Get->>employees Table: query
+    employees Table-->>Employees_Get: entities
+    Employees_Get-->>Client: XHR Response (employees)
+```
+
+Create employee
+
+```mermaid
+sequenceDiagram
+    autonumber
+    Client->>Employees_Create: XHR Request (employee)
+    Employees_Create-->>employees Table: Function output (entity)
+    Employees_Create-->>Client: XHR Response (200)
+```
+
+Create payroll
+
+```mermaid
+sequenceDiagram
+    autonumber
+    Client->>Payroll_Create: XHR Request (payroll)
+    Payroll_Create->>payrolls Table: query (entity)
+    payrolls Table-->>Payroll_Create: entity
+    Payroll_Create->>payroll updates Queue: message (entity)
+    par
+      payroll updates Queue->>PayrollQueue_Update: message (entity)
+      PayrollQueue_Update->>employees Table: query (entity)
+      employees Table-->>PayrollQueue_Update: entity
+      PayrollQueue_Update->>employees Table: update (entity)
+      PayrollQueue_Update->>employeePayrolls Table: update (entity)
+    and
+      Payroll_Create-->>Client: XHR Response (payroll)
+    end
+```

--- a/payroll-processor.code-workspace
+++ b/payroll-processor.code-workspace
@@ -1,6 +1,10 @@
 {
   "folders": [
     {
+      "path": "docs",
+      "name": "docs"
+    },
+    {
       "path": "payroll-processor-api",
       "name": "api"
     },
@@ -28,6 +32,7 @@
       "payroll-processor-api": true,
       "payroll-processor-client": true,
       "payroll-processor-functions": true,
+      "docs": true,
       "**/bin": true,
       "**/obj": true,
       "**/dist": true
@@ -60,7 +65,8 @@
       "dozerg.tsimportsorter",
       "stylelint.vscode-stylelint",
       "k--kato.docomment",
-      "jchannon.csharpextensions"
+      "jchannon.csharpextensions",
+      "vstirbu.vscode-mermaid-preview"
     ]
   }
 }


### PR DESCRIPTION
Adds [mermaidjs](https://mermaidjs.github.io/#/) diagrams to a docs folder and a [mermaid preview](https://marketplace.visualstudio.com/items?itemName=vstirbu.vscode-mermaid-preview) extension for VS Code.

If we want to export these diagrams to SVG so they show up in docs outside of VS Code we can use the [mermaid CLI](https://www.npmjs.com/package/@mermaid-js/mermaid-cli) which can render the mermaid syntax into image files.