### PR TITLE
Hide payroll create when disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ Areas of interest:
 
 - [x] Create
 - [x] Read
-- [ ] Update
-- [ ] Delete
 
 ### Future Enhancements
 

--- a/client/src/app/employee/employee-detail/employee-detail.component.html
+++ b/client/src/app/employee/employee-detail/employee-detail.component.html
@@ -81,7 +81,7 @@
       [payrolls]="employee.payrolls"
     ></app-employee-payroll-list>
   </div>
-  <div class="col-3 pt-3">
+  <div class="col-3 pt-3" *ngIf="employee.status === 'Enabled'">
     <app-employee-payroll-create
       [employee]="employee"
     ></app-employee-payroll-create>

--- a/client/src/app/employee/employee-payroll-list/employee-payroll-list.component.ts
+++ b/client/src/app/employee/employee-payroll-list/employee-payroll-list.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input } from '@angular/core';
+
 import { EmployeePayroll } from '@employee/employee-detail/state/employee-detail.model';
 
 @Component({


### PR DESCRIPTION
# Description

-hides the ability to create employee payrolls when the employee is disabled
-update readme for newest mvp features

## Purpose

- [x] Feature
- [ ] Partial Feature
- [ ] Bugfix
- [x] Docs, Config
- [ ] Chore / Format

## Change Type

- [ ] Major
- [x] Minor
- [ ] Fix

## Data Persistence Changes

none

## Configuration Changes

none
