### PR TITLE
Convert Employee Commands to CSharpFunctionalExtensions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -112,7 +112,7 @@ csharp_style_unused_value_assignment_preference = discard_variable:suggestion
 csharp_style_unused_value_expression_statement_preference = discard_variable:silent
 
 # 'using' directive preferences
-csharp_using_directive_placement = outside_namespace:silent
+csharp_using_directive_placement = outside_namespace:suggestion
 
 #### C# Formatting Rules ####
 

--- a/api/Directory.Build.props
+++ b/api/Directory.Build.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/api/Directory.Packages.props
+++ b/api/Directory.Packages.props
@@ -3,42 +3,43 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Ardalis.ApiEndpoints" Version="4.0.1" />
-    <PackageVersion Include="Ardalis.GuardClauses" Version="4.0.1" />
-    <PackageVersion Include="AutoFixture" Version="4.17.0" />
-    <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.17.0" />
-    <PackageVersion Include="AutoFixture.Idioms" Version="4.17.0" />
-    <PackageVersion Include="AutoFixture.Xunit2" Version="4.17.0" />
-    <PackageVersion Include="AutoMapper" Version="12.0.0" />
-    <PackageVersion Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
-    <PackageVersion Include="Azure.Storage.Queues" Version="12.11.1" />
+    <PackageVersion Include="Ardalis.ApiEndpoints" Version="4.1.0" />
+    <PackageVersion Include="Ardalis.GuardClauses" Version="4.1.1" />
+    <PackageVersion Include="AutoFixture" Version="4.18.0" />
+    <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.0" />
+    <PackageVersion Include="AutoFixture.Idioms" Version="4.18.0" />
+    <PackageVersion Include="AutoFixture.Xunit2" Version="4.18.0" />
+    <PackageVersion Include="AutoMapper" Version="12.0.1" />
+    <PackageVersion Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+    <PackageVersion Include="Azure.Storage.Queues" Version="12.15.0" />
     <PackageVersion Include="Bogus" Version="34.0.2" />
-    <PackageVersion Include="coverlet.collector" Version="3.1.2">
+    <PackageVersion Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="CSharpFunctionalExtensions.FluentAssertions" Version="1.1.0" />
-    <PackageVersion Include="FluentAssertions" Version="6.8.0" />
-    <PackageVersion Include="LanguageExt.Core" Version="4.2.9" />
+    <PackageVersion Include="CSharpFunctionalExtensions" Version="2.40.1" />
+    <PackageVersion Include="CSharpFunctionalExtensions.FluentAssertions" Version="2.0.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="LanguageExt.Core" Version="4.4.4" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.31.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
+    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.35.3" />
     <PackageVersion Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.1" />
+    <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.2.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
+    <PackageVersion Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
     <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.10" />
     <PackageVersion Include="NewtonSoft.Json" Version="13.0.1" />
-    <PackageVersion Include="NSubstitute" Version="4.4.0" />
-    <PackageVersion Include="Scrutor" Version="4.2.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.4.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="6.4.0" />
-    <PackageVersion Include="xunit" Version="2.4.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageVersion Include="NSubstitute" Version="5.0.0" />
+    <PackageVersion Include="Scrutor" Version="4.2.2" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
+    <PackageVersion Include="xunit" Version="2.5.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>

--- a/api/PayrollProcessor.Core.Domain.Tests/PayrollProcessor.Core.Domain.Tests.csproj
+++ b/api/PayrollProcessor.Core.Domain.Tests/PayrollProcessor.Core.Domain.Tests.csproj
@@ -11,9 +11,15 @@
     <PackageReference Include="CSharpFunctionalExtensions.FluentAssertions" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit"/>
-    <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/api/PayrollProcessor.Core.Domain/Intrastructure/Operations/Commands/IStranglerCommandDispatcher.cs
+++ b/api/PayrollProcessor.Core.Domain/Intrastructure/Operations/Commands/IStranglerCommandDispatcher.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using CSharpFunctionalExtensions;
+
+namespace PayrollProcessor.Core.Domain.Intrastructure.Operations.Commands;
+public interface IStranglerCommandDispatcher
+{
+    Result Dispatch(ICommand command, CancellationToken token = default);
+
+    Result<TResponse> Dispatch<TResponse>(ICommand<TResponse> command, CancellationToken token = default);
+}

--- a/api/PayrollProcessor.Core.Domain/Intrastructure/Operations/Commands/IStranglerCommandHandler.cs
+++ b/api/PayrollProcessor.Core.Domain/Intrastructure/Operations/Commands/IStranglerCommandHandler.cs
@@ -1,0 +1,13 @@
+using System.Threading;
+using CSharpFunctionalExtensions;
+
+namespace PayrollProcessor.Core.Domain.Intrastructure.Operations.Commands;
+public interface IStranglerCommandHandler<TCommand> where TCommand : ICommand
+{
+    Result Execute(TCommand command, CancellationToken token);
+}
+
+public interface IStranglerCommandHandler<TCommand, TResponse> where TCommand : ICommand<TResponse>
+{
+    Result<TResponse> Execute(TCommand command, CancellationToken token);
+}

--- a/api/PayrollProcessor.Core.Domain/Intrastructure/Operations/Commands/StranglerCommandDispatcher.cs
+++ b/api/PayrollProcessor.Core.Domain/Intrastructure/Operations/Commands/StranglerCommandDispatcher.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using Ardalis.GuardClauses;
+using CSharpFunctionalExtensions;
+using PayrollProcessor.Core.Domain.Intrastructure.Operations.Factories;
+
+namespace PayrollProcessor.Core.Domain.Intrastructure.Operations.Commands;
+
+/// <summary>
+/// TODO: Temporarily named after the Strangler Fig Pattern as this serves as an implementation of <see cref="ICommandDispatcher"/> migrating to CSharpFunctionalExtensions from LanguageExt.
+/// </summary>
+public class StranglerCommandDispatcher : IStranglerCommandDispatcher
+{
+    private readonly ServiceProviderDelegate serviceProvider;
+    private static readonly ConcurrentDictionary<Type, object> commandHandlers = new ConcurrentDictionary<Type, object>();
+
+    public StranglerCommandDispatcher(ServiceProviderDelegate serviceProvider)
+    {
+        Guard.Against.Null(serviceProvider, nameof(serviceProvider));
+
+        this.serviceProvider = serviceProvider;
+    }
+
+    public Result Dispatch(ICommand command, CancellationToken token = default)
+    {
+        Guard.Against.Null(command, nameof(command));
+
+        var commandType = command.GetType();
+
+        var handler = (StranglerCommandHandlerWrapper)commandHandlers
+            .GetOrAdd(
+                commandType,
+#pragma warning disable CS8603 // Possible null reference return.
+                    t => Activator
+                        .CreateInstance(typeof(StranglerCommandHandlerWrapperImpl<>)
+                        .MakeGenericType(commandType)));
+#pragma warning restore CS8603 // Possible null reference return.
+
+        return handler.Dispatch(command, serviceProvider, token);
+    }
+
+    public Result<TResponse> Dispatch<TResponse>(ICommand<TResponse> command, CancellationToken token = default)
+    {
+        Guard.Against.Null(command, nameof(command));
+
+        var commandType = command.GetType();
+
+        var handler = (StranglerCommandHandlerWrapper<TResponse>)commandHandlers
+            .GetOrAdd(
+                commandType,
+#pragma warning disable CS8603 // Possible null reference return.
+                    t => Activator
+                        .CreateInstance(typeof(StranglerCreateCommandHandlerWrapperImpl<,>)
+                        .MakeGenericType(commandType, typeof(TResponse))));
+#pragma warning restore CS8603 // Possible null reference return.
+
+        return handler.Dispatch(command, serviceProvider, token);
+    }
+}
+
+internal abstract class StranglerCommandHandlerWrapper : HandlerBase
+{
+    public abstract Result Dispatch(ICommand command, ServiceProviderDelegate serviceProvider, CancellationToken token);
+}
+
+internal class StranglerCommandHandlerWrapperImpl<TCommand> : StranglerCommandHandlerWrapper
+    where TCommand : ICommand
+{
+    public override Result Dispatch(ICommand command, ServiceProviderDelegate serviceProvider, CancellationToken token) =>
+        GetHandler<IStranglerCommandHandler<TCommand>>(serviceProvider).Execute((TCommand)command, token);
+}
+
+internal abstract class StranglerCommandHandlerWrapper<TResponse> : HandlerBase
+{
+    public abstract Result<TResponse> Dispatch(ICommand<TResponse> command, ServiceProviderDelegate serviceProvider, CancellationToken token);
+}
+
+internal class StranglerCreateCommandHandlerWrapperImpl<TCommand, TResponse> : StranglerCommandHandlerWrapper<TResponse>
+    where TCommand : ICommand<TResponse>
+{
+    public override Result<TResponse> Dispatch(ICommand<TResponse> command, ServiceProviderDelegate serviceProvider, CancellationToken token) =>
+        GetHandler<IStranglerCommandHandler<TCommand, TResponse>>(serviceProvider).Execute((TCommand)command, token);
+}

--- a/api/PayrollProcessor.Core.Domain/PayrollProcessor.Core.Domain.csproj
+++ b/api/PayrollProcessor.Core.Domain/PayrollProcessor.Core.Domain.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" />
+    <PackageReference Include="CSharpFunctionalExtensions" />
     <PackageReference Include="LanguageExt.Core" />
     <PackageReference Include="NewtonSoft.Json" />
   </ItemGroup>

--- a/api/PayrollProcessor.Data.Persistence.Tests/PayrollProcessor.Data.Persistence.Tests.csproj
+++ b/api/PayrollProcessor.Data.Persistence.Tests/PayrollProcessor.Data.Persistence.Tests.csproj
@@ -11,8 +11,14 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/api/PayrollProcessor.Functions.Api.Tests/PayrollProcessor.Functions.Api.Tests.csproj
+++ b/api/PayrollProcessor.Functions.Api.Tests/PayrollProcessor.Functions.Api.Tests.csproj
@@ -13,8 +13,14 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/api/PayrollProcessor.Web.Api.Tests/PayrollProcessor.Web.Api.Tests.csproj
+++ b/api/PayrollProcessor.Web.Api.Tests/PayrollProcessor.Web.Api.Tests.csproj
@@ -10,8 +10,14 @@
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/api/PayrollProcessor.Web.Api/Features/Employees/EmployeeCreate.cs
+++ b/api/PayrollProcessor.Web.Api/Features/Employees/EmployeeCreate.cs
@@ -12,7 +12,7 @@ using Swashbuckle.AspNetCore.Annotations;
 
 namespace PayrollProcessor.Web.Api.Features.Employees;
 
-public class EmployeeCreate : EndpointBaseAsync
+public class EmployeeCreate : EndpointBaseSync
     .WithRequest<EmployeeCreateRequest>
     .WithActionResult<Employee>
 {
@@ -35,7 +35,7 @@ public class EmployeeCreate : EndpointBaseAsync
         OperationId = "Employees.Create",
         Tags = new[] { "Employees" })
     ]
-    public override Task<ActionResult<Employee>> HandleAsync([FromBody] EmployeeCreateRequest request, CancellationToken token)
+    public override ActionResult<Employee> Handle([FromBody] EmployeeCreateRequest request)
     {
         var command = new EmployeeCreateCommand(
             generator.Generate(),
@@ -51,11 +51,11 @@ public class EmployeeCreate : EndpointBaseAsync
                 Title = request.Title
             });
 
-        return Task.FromResult(dispatcher
-            .Dispatch(command, token)
+        return dispatcher
+            .Dispatch(command)
             .Match<ActionResult<Employee>, Employee>(
                 onSuccess: employee => Ok(employee),
-                onFailure: ex => new APIErrorResult(ex)));
+                onFailure: ex => new APIErrorResult(ex));
     }
 }
 

--- a/payroll-processor.code-workspace
+++ b/payroll-processor.code-workspace
@@ -52,12 +52,11 @@
       */
       "editor.codeActionsOnSave": {}
     },
-
-    "omnisharp.defaultLaunchSolution": "PayrollProcessor.sln",
     "omnisharp.autoStart": true,
     "omnisharp.enableEditorConfigSupport": true,
     "omnisharp.enableRoslynAnalyzers": true,
-    "omnisharp.useEditorFormattingSettings": true
+    "omnisharp.useEditorFormattingSettings": true,
+    "dotnet.defaultSolution": "PayrollProcessor.sln"
   },
   "extensions": {
     "recommendations": [


### PR DESCRIPTION
# Description

- Adds foundation for migrating to CSharpFunctionalExtensions feature by feature rather than an all or nothing "big bang" approach by using the Strangler Fig pattern. 

## Purpose

- [ ] Feature
- [x] Partial Feature
- [ ] Bugfix
- [ ] Docs, Config
- [ ] Chore / Format

## Change Type

- [x] Major
- [ ] Minor
- [ ] Fix

## Data Persistence Changes

N/A

## Configuration Changes

N/A